### PR TITLE
hotfix: removed outDir config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   plugins: [svelte()],
   base: "/Rozvazej.Registration/",
   build: {
-    outDir: "dist/Rozvazej.Registration",
     rollupOptions: {
       output: {
         entryFileNames: "multi-step.js",


### PR DESCRIPTION
This hotfix removes the outDir config and should keep the forms the same without dropdown conflicts